### PR TITLE
把HTTP Header暴露出去，解决代理环境难以获取真实IP的问题。

### DIFF
--- a/packages/pinus/lib/connectors/hybrid/wsprocessor.ts
+++ b/packages/pinus/lib/connectors/hybrid/wsprocessor.ts
@@ -22,7 +22,9 @@ export class WSProcessor extends EventEmitter {
         let self = this;
         this.wsServer = new WebSocket.Server({ server: this.httpServer });
 
-        this.wsServer.on('connection', function (socket) {
+        this.wsServer.on('connection', function (socket, req) {
+            // pass http headers to outside, easy get real ip via http headers
+            socket.headers = req.headers;
             // emit socket to outside
             self.emit('connection', socket);
         });


### PR DESCRIPTION
通过 session.__session__.__socket__.socket.headers['x-real-ip'] 获取。